### PR TITLE
added hidden clubId input to searchbar on search.html 

### DIFF
--- a/next-chapter/src/main/resources/templates/search.html
+++ b/next-chapter/src/main/resources/templates/search.html
@@ -30,7 +30,13 @@
 
 <h5>Didn't find what you're looking for?
     <br>Try again with a different keyword, or consider including the author's name.</h5>
-<div th:replace="fragments :: searchbar"></div>
+<form action="search.html" th:attr="action=@{/search}">
+    <div class="input-group mb-3">
+        <input type="text" name="query" class="form-control" placeholder="Search for a title" aria-label="Search query" aria-describedby="button-addon2">
+        <input type="hidden" name="clubId" th:value="${clubId}">
+        <button type="submit" class="btn btn-outline-secondary" id="button-addon2">Search</button>
+    </div>
+</form>
 
 </body>
 </html>


### PR DESCRIPTION
so club info passes through a second search.

In case someone makes a typo when searching for the title of the book they are searching for. They can just immediately do a search from the search results page, and the clubId will pass through appropriately.